### PR TITLE
fix: UTC datetimes in commands and unit timezone in confirmation display

### DIFF
--- a/src/Command/DailyCommand.php
+++ b/src/Command/DailyCommand.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Novosga\SchedulingBundle\Command;
 
 use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\ORM\EntityManagerInterface;
 use Novosga\Entity\AgendamentoInterface;
 use Novosga\Repository\AgendamentoRepositoryInterface;
@@ -53,8 +55,7 @@ class DailyCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Novo SGA Scheduling Daily');
 
-        $today = new DateTime();
-        $today->setTime(0, 0, 0, 0);
+        $today = new DateTimeImmutable('today', new DateTimeZone('UTC'));
         $limit = 100;
         $offset = 0;
 

--- a/src/Command/DailyCommand.php
+++ b/src/Command/DailyCommand.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Novosga\SchedulingBundle\Command;
 
-use DateTime;
-use DateTimeImmutable;
-use DateTimeZone;
 use Doctrine\ORM\EntityManagerInterface;
 use Novosga\Entity\AgendamentoInterface;
+use Novosga\Entity\UnidadeInterface;
 use Novosga\Repository\AgendamentoRepositoryInterface;
+use Novosga\Repository\UnidadeRepositoryInterface;
 use Novosga\SchedulingBundle\Service\ConfigService;
 use Novosga\SchedulingBundle\Service\ExternalApiClientFactory;
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,7 +45,9 @@ class DailyCommand extends Command
         private readonly EntityManagerInterface $em,
         private readonly ConfigService $configService,
         private readonly ExternalApiClientFactory $clientFactory,
-        private readonly AgendamentoRepositoryInterface $agendamentoRepository
+        private readonly UnidadeRepositoryInterface $unidadeRepository,
+        private readonly AgendamentoRepositoryInterface $agendamentoRepository,
+        private readonly ClockInterface $clock,
     ) {
         parent::__construct();
     }
@@ -55,15 +57,44 @@ class DailyCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Novo SGA Scheduling Daily');
 
-        $today = new DateTimeImmutable('today', new DateTimeZone('UTC'));
+
+        /** @var UnidadeInterface[] */
+        $unidades = $this->unidadeRepository->findBy([
+            'ativo' => true,
+        ]);
+
+        foreach ($unidades as $unidade) {
+            $io->info(sprintf(
+                '[unidade-%s] Checking appointments for Unit %s',
+                $unidade->getId(),
+                $unidade->getNome(),
+            ));
+
+            $this->handleUnidade($unidade, $io);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function handleUnidade(UnidadeInterface $unidade, SymfonyStyle $io): void
+    {
+        $today = $this->clock->now()->setTimezone($unidade->getDateTimeZone());
         $limit = 100;
         $offset = 0;
+
+        $io->text(sprintf(
+            '[unidade-%s] Current unit datetime: %s',
+            $unidade->getId(),
+            $today->format('Y-m-d H:i:s'),
+        ));
 
         $query = $this
             ->agendamentoRepository
             ->createQueryBuilder('e')
-            ->where('e.situacao = :situacao')
+            ->where('e.unidade = :unidade')
+            ->andWhere('e.situacao = :situacao')
             ->andWhere('e.data < :today')
+            ->setParameter('unidade', $unidade->getId())
             ->setParameter('situacao', AgendamentoInterface::SITUACAO_AGENDADO)
             ->setParameter('today', $today)
             ->setMaxResults($limit)
@@ -77,7 +108,8 @@ class DailyCommand extends Command
             /** @var AgendamentoInterface $agendamento */
             foreach ($agendamentos as $agendamento) {
                 $io->text(sprintf(
-                    "Updating schedule ID %s, date %s",
+                    "[unidade-%s] Updating appointment ID %s, date %s",
+                    $unidade->getId(),
                     $agendamento->getId(),
                     $agendamento->getData()->format('Y-m-d'),
                 ));
@@ -99,7 +131,8 @@ class DailyCommand extends Command
                     );
                 } catch (Throwable $ex) {
                     $io->error(sprintf(
-                        "Failed to update remove schedule (OID: %s): %s",
+                        "[unidade-%s] Failed to update remove appointment (OID: %s): %s",
+                        $unidade->getId(),
                         $agendamento->getOid(),
                         $ex->getMessage()
                     ));
@@ -109,6 +142,10 @@ class DailyCommand extends Command
             $offset += count($agendamentos);
         } while (!empty($agendamentos));
 
-        return Command::SUCCESS;
+        $io->text(sprintf(
+            '[unidade-%s] Total appointments found: %s',
+            $unidade->getId(),
+            $offset,
+        ));
     }
 }

--- a/src/Command/DailyCommand.php
+++ b/src/Command/DailyCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Novosga\SchedulingBundle\Command;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Novosga\Entity\AgendamentoInterface;
 use Novosga\Entity\UnidadeInterface;
@@ -96,7 +97,7 @@ class DailyCommand extends Command
             ->andWhere('e.data < :today')
             ->setParameter('unidade', $unidade->getId())
             ->setParameter('situacao', AgendamentoInterface::SITUACAO_AGENDADO)
-            ->setParameter('today', $today)
+            ->setParameter('today', $today, Types::DATE_IMMUTABLE)
             ->setMaxResults($limit)
             ->getQuery();
 

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -14,9 +14,6 @@ declare(strict_types=1);
 namespace Novosga\SchedulingBundle\Command;
 
 use DateInterval;
-use DateTime;
-use DateTimeImmutable;
-use DateTimeZone;
 use Novosga\Entity\AgendamentoInterface;
 use Novosga\Entity\UnidadeInterface;
 use Novosga\Repository\AgendamentoRepositoryInterface;
@@ -27,6 +24,7 @@ use Novosga\SchedulingBundle\Service\ConfigService;
 use Novosga\SchedulingBundle\Service\ExternalApiClientFactory;
 use Novosga\SchedulingBundle\ValueObject\ServicoConfig;
 use Novosga\SchedulingBundle\ValueObject\UnidadeConfig;
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -55,6 +53,7 @@ class SyncCommand extends Command
         private readonly ExternalApiClientFactory $clientFactory,
         private readonly UnidadeRepositoryInterface $unidadeRepository,
         private readonly AgendamentoRepositoryInterface $agendamentoRepository,
+        private readonly ClockInterface $clock,
     ) {
         parent::__construct();
     }
@@ -64,23 +63,40 @@ class SyncCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Novo SGA Scheduling Sync');
 
-        $this->syncLocalToRemove($io);
-        $this->syncRemoteToLocal($io);
+        /** @var UnidadeInterface[] */
+        $unidades = $this->unidadeRepository->findBy([
+            'ativo' => true,
+        ]);
+
+        foreach ($unidades as $unidade) {
+            $io->info(sprintf(
+                '[unidade-%s] Syncing appointments for Unit %s',
+                $unidade->getId(),
+                $unidade->getNome(),
+            ));
+
+            $this->syncLocalToRemove($unidade, $io);
+            $this->syncRemoteToLocal($unidade, $io);
+        }
 
         return Command::SUCCESS;
     }
 
-    private function syncLocalToRemove(SymfonyStyle $io): void
+    private function syncLocalToRemove(UnidadeInterface $unidade, SymfonyStyle $io): void
     {
-        $today = new DateTimeImmutable('today', new DateTimeZone('UTC'));
+        $io->text(sprintf("[unidade-%s] Updating remote from local", $unidade->getId()));
+
+        $today = $this->clock->now()->setTimezone($unidade->getDateTimeZone());
         $limit = 100;
         $offset = 0;
 
         $query = $this
             ->agendamentoRepository
             ->createQueryBuilder('e')
-            ->where('e.situacao = :situacao')
+            ->where('e.unidade = :unidade')
+            ->andWhere('e.situacao = :situacao')
             ->andWhere('e.data >= :today')
+            ->setParameter('unidade', $unidade->getId())
             ->setParameter('situacao', AgendamentoInterface::SITUACAO_CONFIRMADO)
             ->setParameter('today', $today)
             ->setMaxResults($limit)
@@ -94,7 +110,7 @@ class SyncCommand extends Command
             /** @var AgendamentoInterface $agendamento */
             foreach ($agendamentos as $agendamento) {
                 $io->text(sprintf(
-                    "Updating schedule ID %s, date %s",
+                    "Updating appointment ID %s, date %s",
                     $agendamento->getId(),
                     $agendamento->getData()->format('Y-m-d'),
                 ));
@@ -112,7 +128,7 @@ class SyncCommand extends Command
                     );
                 } catch (Throwable $ex) {
                     $io->error(sprintf(
-                        "Failed to update remove schedule (OID: %s): %s",
+                        "Failed to update remove appointment (OID: %s): %s",
                         $agendamento->getOid(),
                         $ex->getMessage(),
                     ));
@@ -123,26 +139,23 @@ class SyncCommand extends Command
         } while (!empty($agendamentos));
     }
 
-    private function syncRemoteToLocal(SymfonyStyle $io): void
+    private function syncRemoteToLocal(UnidadeInterface $unidade, SymfonyStyle $io): void
     {
-        $unidades = $this->unidadeRepository->findAll();
+        $io->text(sprintf("[unidade-%s] Updating local remote", $unidade->getId()));
 
-        /** @var UnidadeInterface $unidade */
-        foreach ($unidades as $unidade) {
-            $unidadeConfig = $this->configService->getUnidadeConfig($unidade);
-            if ($unidadeConfig) {
-                $io->section("Config found for unity {$unidade->getNome()}");
-                $servicoConfigs = $this->configService->getServicoConfigs($unidade);
-                if (!count($servicoConfigs)) {
-                    $io->info("No services config found");
-                }
-                foreach ($servicoConfigs as $servicoConfig) {
-                    try {
-                        $io->text("Syncing schedule for service {$servicoConfig->servicoLocal->getNome()} ... ");
-                        $this->doSyncRemoteToLocal($io, $unidade, $unidadeConfig, $servicoConfig);
-                    } catch (Throwable $e) {
-                        $io->error($e->getMessage());
-                    }
+        $unidadeConfig = $this->configService->getUnidadeConfig($unidade);
+        if ($unidadeConfig) {
+            $io->section("Config found for unity {$unidade->getNome()}");
+            $servicoConfigs = $this->configService->getServicoConfigs($unidade);
+            if (!count($servicoConfigs)) {
+                $io->info("No services config found");
+            }
+            foreach ($servicoConfigs as $servicoConfig) {
+                try {
+                    $io->text("Syncing appointment for service {$servicoConfig->servicoLocal->getNome()} ... ");
+                    $this->doSyncRemoteToLocal($io, $unidade, $unidadeConfig, $servicoConfig);
+                } catch (Throwable $e) {
+                    $io->error($e->getMessage());
                 }
             }
         }
@@ -156,7 +169,7 @@ class SyncCommand extends Command
     ): void {
         $total = 0;
         $totalSaved = 0;
-        $startDate = new DateTimeImmutable();
+        $startDate = $this->clock->now()->setTimezone($unidade->getDateTimeZone());
         $days = 0;
         $client = $this->getClient($unidade, $unidadeConfig);
 

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Novosga\SchedulingBundle\Command;
 
 use DateInterval;
+use Doctrine\DBAL\Types\Types;
 use Novosga\Entity\AgendamentoInterface;
 use Novosga\Entity\UnidadeInterface;
 use Novosga\Repository\AgendamentoRepositoryInterface;
@@ -98,7 +99,7 @@ class SyncCommand extends Command
             ->andWhere('e.data >= :today')
             ->setParameter('unidade', $unidade->getId())
             ->setParameter('situacao', AgendamentoInterface::SITUACAO_CONFIRMADO)
-            ->setParameter('today', $today)
+            ->setParameter('today', $today, Types::DATE_IMMUTABLE)
             ->setMaxResults($limit)
             ->getQuery();
 

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -16,6 +16,7 @@ namespace Novosga\SchedulingBundle\Command;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use Novosga\Entity\AgendamentoInterface;
 use Novosga\Entity\UnidadeInterface;
 use Novosga\Repository\AgendamentoRepositoryInterface;
@@ -71,8 +72,7 @@ class SyncCommand extends Command
 
     private function syncLocalToRemove(SymfonyStyle $io): void
     {
-        $today = new DateTime();
-        $today->setTime(0, 0, 0, 0);
+        $today = new DateTimeImmutable('today', new DateTimeZone('UTC'));
         $limit = 100;
         $offset = 0;
 

--- a/src/Resources/views/default/form.html.twig
+++ b/src/Resources/views/default/form.html.twig
@@ -20,7 +20,7 @@
 
     {% if entity.dataConfirmacao %}
         <div class="alert alert-info">
-            Confirmada presença do agendamento e senha gerada em <strong>{{ entity.dataConfirmacao|date('d/m/Y H:i:s') }}</strong>.
+            Confirmada presença do agendamento e senha gerada em <strong>{{ entity.dataConfirmacao|date('d/m/Y H:i:s', entity.unidade.timezone) }}</strong>.
         </div>
     {% endif %}
         


### PR DESCRIPTION
Issue: https://github.com/novosga/novosga/issues/454

Related to https://github.com/novosga/novosga/pull/492

## Summary

- `DailyCommand` and `SyncCommand`: replace `new DateTime()` + `setTime()` with `new DateTimeImmutable('today', new DateTimeZone('UTC'))` so the cutoff date is always UTC-midnight, matching UTC-stored database values
- `form.html.twig`: pass `entity.unidade.timezone` to the `date()` filter for the confirmation datetime display

## Test plan

- [x] Run `novosga:scheduling:daily` and verify past-date appointments are expired correctly
- [x] Run `novosga:scheduling:sync` and verify sync operates on the correct date range
- [x] Open a confirmed scheduling form for a unit with a non-UTC timezone and verify the confirmation time displays in local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)