### PR TITLE
chore: upgrade Symfony from 7.1 to 7.4 LTS (#455)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,14 @@
     "license": "MIT",
     "type": "symfony-bundle",
     "autoload": {
-        "psr-4": { "Novosga\\SchedulingBundle\\": "src/" }
+        "psr-4": {
+            "Novosga\\SchedulingBundle\\": "src/"
+        }
     },
     "autoload-dev": {
-        "psr-4": { "Novosga\\SchedulingBundle\\Tests\\": "tests/" }
+        "psr-4": {
+            "Novosga\\SchedulingBundle\\Tests\\": "tests/"
+        }
     },
     "require": {
         "php": ">=8.2",
@@ -14,12 +18,12 @@
         "novosga/core": "2.3.x-dev",
         "pagerfanta/doctrine-orm-adapter": "*",
         "pagerfanta/pagerfanta": "^4.6",
-        "symfony/framework-bundle": "7.1.*",
-        "symfony/form": "7.1.*",
-        "symfony/security-core": "7.1.*",
-        "symfony/validator": "7.1.*",
-        "symfony/http-client": "7.1.*",
-        "symfony/security-bundle": "7.1.*"
+        "symfony/framework-bundle": "7.4.*",
+        "symfony/form": "7.4.*",
+        "symfony/security-core": "7.4.*",
+        "symfony/validator": "7.4.*",
+        "symfony/http-client": "7.4.*",
+        "symfony/security-bundle": "7.4.*"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
## Summary

Part of novosga/novosga#455 — main PR: novosga/novosga#495.

Bumps all `symfony/*` constraints from `7.1.*` → `7.4.*` in `composer.json`.

## Test plan

- [x] `composer install` resolves cleanly
- [x] `vendor/bin/phpunit` passes
- [x] `vendor/bin/phpstan` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)